### PR TITLE
read#handleRawResponse: return an array

### DIFF
--- a/lib/read.js
+++ b/lib/read.js
@@ -6,7 +6,8 @@ let db = require('./db');
 
 class Read extends SqlCommonRead {
     handleRawResponse(resp) {
-        return resp[0];
+        let firstItem = resp[0];
+        return _.isArray(firstItem) ? firstItem : [ firstItem ];
     }
 
     addPointFormatting(points, targets) {


### PR DESCRIPTION
When DDL statements like 'CREATE TABLE' are run, the first item of the response is an object instead of an array. Wrap it into an array in these situations.

I didn't do a thorough investigation of why this used to work fine and doesn't now. Either we used to do this wrapping somewhere downstream (perhaps even in core juttle) or knex used to return an array in the first item. Either way, we should ensure that the returned value is an array.

@VladVega @demmer @rlgomes